### PR TITLE
Fixed replacing URLs in CSS for something like data:image/png

### DIFF
--- a/EClientScript.php
+++ b/EClientScript.php
@@ -404,14 +404,14 @@ class EClientScript extends CClientScript
 	 * @param integer $position the position of the JavaScript code.
 	 * @return CClientScript the CClientScript object itself
 	 */
-	public function registerScript($id, $script, $postion = null)
+	public function registerScript($id, $script, $position = null)
 	{
 		if (!YII_DEBUG)
 		{
 			$script = $this->optimizeScriptCode($script);
 		}
 
-		return parent($id, $script, $position);
+		return parent::registerScript($id, $script, $position);
 	}
 
 	/**


### PR DESCRIPTION
When CSS file contains something like this

``` css
background-image: url(data:image/png;base64,iVBOoAAAAN…wcUVORK5CYII=);
```

there were incorrect replacements with

``` css
background-image: url(ff0a9447/css/data:image/png;base64,iVBOoAAAAN…wcUVORK5CYII=);
```
