### PR TITLE
prevent combining of external js with src like "//api-maps.yandex.ru/2.0...

### DIFF
--- a/EClientScript.php
+++ b/EClientScript.php
@@ -304,7 +304,7 @@ class EClientScript extends CClientScript
 		$indexCombine = 0;
 		$scriptName = $scriptValue = array();
 		foreach ($this->scriptFiles[$type] as $url => $value) {
-			if (is_array($value) || !($file = $this->getLocalPath($url))) {
+			if (is_array($value) || !($file = $this->getLocalPath($url)) || strpos($url,'//')!==false ) {
 				$scriptName[] = $url;
 				$scriptValue[] = $value;
 			} else {


### PR DESCRIPTION
.../?load=package.full&amp;lang=ru-RU"

Sometimes we need automatically detect protocol of web site (http / https), including js files as "//api-maps.yandex.ru/2.0/?load=package.full&amp;lang=ru-RU" (2 slashes in the beginning). Such files are combining. So I added one more check - strpos($url,'//')!==false . Assuming that $url contain 2 slashes only for protocol.