### PR TITLE
Check on double slashes in case, for urls using auto detection protocol

### DIFF
--- a/EClientScript.php
+++ b/EClientScript.php
@@ -365,7 +365,7 @@ class EClientScript extends CClientScript
 	private function getLocalPath($url)
 	{
 		foreach ($this->_baseUrlMap as $baseUrl => $basePath) {
-			if (!strncmp($url, $baseUrl, strlen($baseUrl))) {
+			if (strpos($url, '//') === FALSE && !strncmp($url, $baseUrl, strlen($baseUrl))) {
 				return $basePath . substr($url, strlen($baseUrl));
 			}
 		}


### PR DESCRIPTION
Hello!
Your ext is pretty good, and i used it for long time, but today i have experienced problem - it throws error if script src looks like `//ulogin.ru/js/ulogin.js`, `//` used to auto detect connection protocol.

![Screenshot](https://dl.dropboxusercontent.com/u/76506086/github/yiiEClientScript/Screenshot%20from%202015-10-01%2014%3A09%3A43.png)

In my commit, i have added check for this case, in getLocalPath method.

Thank you!